### PR TITLE
Bug: ProxyBuilder.callSuper(Object, Method, Object[]) would throw an Ill...

### DIFF
--- a/dexmaker/src/main/java/com/google/dexmaker/stock/ProxyBuilder.java
+++ b/dexmaker/src/main/java/com/google/dexmaker/stock/ProxyBuilder.java
@@ -651,6 +651,20 @@ public final class ProxyBuilder<T> {
                 // Skip static methods, overriding them has no effect.
                 continue;
             }
+            if (!Modifier.isPublic(method.getModifiers())
+					&& !Modifier.isProtected(method.getModifiers())) {
+                // Skip private methods, since they are invoked through direct
+                // invocation (as opposed to virtual). Therefore, it would not
+                // be possible to intercept any private method defined inside
+                // the proxy class except through reflection.
+
+                // Skip package-private methods as well. The proxy class does
+                // not actually inherit package-private methods from the parent
+                // class because it is not a member of the parent's package.
+                // This is even true if the two classes have the same package
+                // name, as they use different class loaders.
+                continue;
+            }
             if (method.getName().equals("finalize") && method.getParameterTypes().length == 0) {
                 // Skip finalize method, it's likely important that it execute as normal.
                 continue;

--- a/dexmaker/src/test/java/com/google/dexmaker/stock/ProxyBuilderTest.java
+++ b/dexmaker/src/test/java/com/google/dexmaker/stock/ProxyBuilderTest.java
@@ -124,7 +124,15 @@ public class ProxyBuilderTest extends TestCase {
     }
 
     public void testProxyingPrivateMethods_NotIntercepted() throws Throwable {
-        assertEquals("expected", proxyFor(HasPrivateMethod.class).build().result());
+        HasPrivateMethod proxy = proxyFor(HasPrivateMethod.class).build();
+        try {
+            proxy.getClass().getDeclaredMethod("result");
+            fail();
+        } catch (NoSuchMethodException e) {
+
+        }
+
+        assertEquals("expected", proxy.result());
     }
 
     public static class HasPackagePrivateMethod {
@@ -133,8 +141,23 @@ public class ProxyBuilderTest extends TestCase {
         }
     }
 
-    public void testProxyingPackagePrivateMethods_AreIntercepted() throws Throwable {
-        assertEquals("fake result", proxyFor(HasPackagePrivateMethod.class).build().result());
+    public void testProxyingPackagePrivateMethods_NotIntercepted()
+            throws Throwable {
+        HasPackagePrivateMethod proxy = proxyFor(HasPackagePrivateMethod.class)
+                .build();
+        try {
+            proxy.getClass().getDeclaredMethod("result");
+            fail();
+        } catch (NoSuchMethodException e) {
+
+        }
+
+        try {
+            proxy.result();
+            fail();
+        } catch (AssertionFailedError e) {
+
+        }
     }
 
     public static class HasProtectedMethod {
@@ -145,6 +168,32 @@ public class ProxyBuilderTest extends TestCase {
 
     public void testProxyingProtectedMethods_AreIntercepted() throws Throwable {
         assertEquals("fake result", proxyFor(HasProtectedMethod.class).build().result());
+    }
+
+    public static class MyParentClass {
+        String someMethod() {
+            return "package";
+        }
+    }
+
+    public static class MyChildClassWithProtectedMethod extends MyParentClass {
+        @Override
+        protected String someMethod() {
+            return "protected";
+        }
+    }
+
+    public static class MyChildClassWithPublicMethod extends MyParentClass {
+        @Override
+        public String someMethod() {
+            return "public";
+        }
+    }
+
+    public void testProxying_ClassHierarchy() throws Throwable {
+        assertEquals("package", proxyFor(MyParentClass.class).build().someMethod());
+        assertEquals("fake result", proxyFor(MyChildClassWithProtectedMethod.class).build().someMethod());
+        assertEquals("fake result", proxyFor(MyChildClassWithPublicMethod.class).build().someMethod());
     }
 
     public static class HasVoidMethod {

--- a/dexmaker/src/test/java/com/google/dexmaker/stock/ProxyBuilderTest.java
+++ b/dexmaker/src/test/java/com/google/dexmaker/stock/ProxyBuilderTest.java
@@ -128,7 +128,7 @@ public class ProxyBuilderTest extends TestCase {
         try {
             proxy.getClass().getDeclaredMethod("result");
             fail();
-        } catch (NoSuchMethodException e) {
+        } catch (NoSuchMethodException expected) {
 
         }
 
@@ -148,14 +148,14 @@ public class ProxyBuilderTest extends TestCase {
         try {
             proxy.getClass().getDeclaredMethod("result");
             fail();
-        } catch (NoSuchMethodException e) {
+        } catch (NoSuchMethodException expected) {
 
         }
 
         try {
             proxy.result();
             fail();
-        } catch (AssertionFailedError e) {
+        } catch (AssertionFailedError expected) {
 
         }
     }


### PR DESCRIPTION
...egalAccessException if a package-private method was intercepted by the proxy.

RCA: ProxyBuilder.getMethodsToProxy() returned a list of methods with public, protected, package-private, and private scopes. It should have only returned methods with public and protected scopes. Private methods in Android are invoked directly, not virtually, so unless reflection is used, the private method inside the proxy class will never be called. Package-private methods are never inherited by the proxy class, since the proxy class does not belong in the same package as the parent class, as they use different class loaders.

Fix: Do not attempt to override private or package-private methods.

Changes:
-Modified ProxyBuilder.getMethodsToProxy() to skip private and package-private methods.
-Updated unit tests for ProxyBuilder to reflect this change.

@dshirley Please review.