### PR TITLE
Explicitly set JarEntry size

### DIFF
--- a/dexmaker/src/main/java/com/google/dexmaker/DexMaker.java
+++ b/dexmaker/src/main/java/com/google/dexmaker/DexMaker.java
@@ -374,7 +374,9 @@ public final class DexMaker {
         File result = File.createTempFile("Generated", ".jar", dexCache);
         result.deleteOnExit();
         JarOutputStream jarOut = new JarOutputStream(new FileOutputStream(result));
-        jarOut.putNextEntry(new JarEntry(DexFormat.DEX_IN_JAR_NAME));
+        JarEntry entry = new JarEntry(DexFormat.DEX_IN_JAR_NAME);
+        entry.setSize(dex.length);
+        jarOut.putNextEntry(entry);
         jarOut.write(dex);
         jarOut.closeEntry();
         jarOut.close();


### PR DESCRIPTION
Help the zip encoder by explicitly setting the size of the dex
content.