### PR TITLE
Feature/add reuse api call

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,14 @@ Maven users can get dexmaker from Sonatype's central repository. The Mockito dep
 
 Download [dexmaker-1.2.jar](http://search.maven.org/remotecontent?filepath=com/google/dexmaker/dexmaker/1.2/dexmaker-1.2.jar)
 and [dexmaker-mockito-1.2.jar](http://search.maven.org/remotecontent?filepath=com/google/dexmaker/dexmaker-mockito/1.2/dexmaker-mockito-1.2.jar).
+
+Run the Unit Tests
+------------------
+
+The unit tests for dexmaker must be run on a dalvikvm. In order to do this, you can use [Vogar](https://code.google.com/p/vogar/) in the following fashion:
+
+```
+$ java -jar vogar.jar --mode device --sourcepath /path/to/dexmaker/dexmaker/src/test/java --sourcepath /path/to/dexmaker/dexmaker/src/main/java --sourcepath /path/to/dexmaker/dx/src/main/java --device-dir /data/dexmaker /path/to/dexmaker/dexmaker/src/test/
+```
+
+Download [vogar.jar](https://vogar.googlecode.com/files/vogar.jar).

--- a/dexmaker/src/main/java/com/google/dexmaker/DexMaker.java
+++ b/dexmaker/src/main/java/com/google/dexmaker/DexMaker.java
@@ -323,6 +323,21 @@ public final class DexMaker {
         }
     }
 
+    private static File assignDexCache() {
+        File dexCache;
+        String property = System.getProperty("dexmaker.dexcache");
+        if (property != null) {
+            dexCache = new File(property);
+        } else {
+            dexCache = new AppDataDirGuesser().guess();
+            if (dexCache == null) {
+                throw new IllegalArgumentException("dexcache == null (and no default could be"
+                        + " found; consider setting the 'dexmaker.dexcache' system property)");
+            }
+        }
+        return dexCache;
+    }
+
     /**
      * Generates a dex file and loads its types into the current process.
      *
@@ -350,16 +365,7 @@ public final class DexMaker {
      */
     public ClassLoader generateAndLoad(ClassLoader parent, File dexCache) throws IOException {
         if (dexCache == null) {
-            String property = System.getProperty("dexmaker.dexcache");
-            if (property != null) {
-                dexCache = new File(property);
-            } else {
-                dexCache = new AppDataDirGuesser().guess();
-                if (dexCache == null) {
-                    throw new IllegalArgumentException("dexcache == null (and no default could be"
-                            + " found; consider setting the 'dexmaker.dexcache' system property)");
-                }
-            }
+            dexCache = assignDexCache();
         }
 
         byte[] dex = generate();

--- a/dexmaker/src/main/java/com/google/dexmaker/stock/ProxyBuilder.java
+++ b/dexmaker/src/main/java/com/google/dexmaker/stock/ProxyBuilder.java
@@ -214,7 +214,12 @@ public final class ProxyBuilder<T> {
         check(handler != null, "handler == null");
         check(constructorArgTypes.length == constructorArgValues.length,
                 "constructorArgValues.length != constructorArgTypes.length");
-        Class<? extends T> proxyClass = buildProxyClass();
+        Class<? extends T> proxyClass;
+        // Prevent a race condition where a class can be generated and written to disk twice.
+        synchronized (baseClass) {
+            proxyClass = buildProxyClass();
+        }
+
         Constructor<? extends T> constructor;
         try {
             constructor = proxyClass.getConstructor(constructorArgTypes);

--- a/dexmaker/src/test/java/com/google/dexmaker/DexMakerTest.java
+++ b/dexmaker/src/test/java/com/google/dexmaker/DexMakerTest.java
@@ -1814,11 +1814,11 @@ public final class DexMakerTest extends TestCase {
         throw new IllegalStateException("no call() method");
     }
 
-    public static File getDataDirectory() throws Exception {
-        Class<?> environmentClass = Class.forName("android.os.Environment");
-        Method method = environmentClass.getMethod("getDataDirectory");
-        Object dataDirectory = method.invoke(null);
-        return (File) dataDirectory;
+    public static File getDataDirectory() {
+        String envVariable = "ANDROID_DATA";
+        String defaultLoc = "/data";
+        String path = System.getenv(envVariable);
+        return path == null ? new File(defaultLoc) : new File(path);
     }
 
     private Class<?> generateAndLoad() throws Exception {

--- a/dexmaker/src/test/java/com/google/dexmaker/examples/FibonacciMaker.java
+++ b/dexmaker/src/test/java/com/google/dexmaker/examples/FibonacciMaker.java
@@ -70,9 +70,9 @@ public final class FibonacciMaker {
     }
 
     public static File getDataDirectory() throws Exception {
-        Class<?> environmentClass = Class.forName("android.os.Environment");
-        Method method = environmentClass.getMethod("getDataDirectory");
-        Object dataDirectory = method.invoke(null);
-        return (File) dataDirectory;
+        String envVariable = "ANDROID_DATA";
+        String defaultLoc = "/data";
+        String path = System.getenv(envVariable);
+        return path == null ? new File(defaultLoc) : new File(path);
     }
 }


### PR DESCRIPTION
@dshirley @swankjesse Please review. It's probably easiest to go commit by commit. The idea behind this change is to allow users to reuse dex classes that were created in previous app sessions, instead of the current behavior where old files in the dex cache directory are ignored. I tried to make the API as minimal as possible.