### PR TITLE
Feature/reuse classes from cache

### DIFF
--- a/dexmaker/src/main/java/com/google/dexmaker/DexMaker.java
+++ b/dexmaker/src/main/java/com/google/dexmaker/DexMaker.java
@@ -327,6 +327,8 @@ public final class DexMaker {
         }
     }
 
+    // Generate a file name for the jar by taking a checksum of MethodIds and
+    // parent class types.
     private String generateFileName() {
         int checksum = 1;
 
@@ -409,6 +411,8 @@ public final class DexMaker {
         }
 
         File result = new File(dexCache, generateFileName());
+        // Check that the file exists. If it does, return a DexClassLoader and skip all
+        // the dex bytecode generation.
         if (result.exists()) {
             return generateClassLoader(result, dexCache, parent);
         }

--- a/dexmaker/src/main/java/com/google/dexmaker/DexMaker.java
+++ b/dexmaker/src/main/java/com/google/dexmaker/DexMaker.java
@@ -341,7 +341,9 @@ public final class DexMaker {
             TypeId<?> typeId = it.next();
             TypeDeclaration decl = getTypeDeclaration(typeId);
             Set<MethodId> methodSet = decl.methods.keySet();
-            checksums[i++] = 31 * decl.supertype.hashCode() + methodSet.hashCode();
+            if (decl.supertype != null) {
+                checksums[i++] = 31 * decl.supertype.hashCode() + methodSet.hashCode();
+            }
         }
         Arrays.sort(checksums);
 

--- a/dexmaker/src/main/java/com/google/dexmaker/stock/ProxyBuilder.java
+++ b/dexmaker/src/main/java/com/google/dexmaker/stock/ProxyBuilder.java
@@ -169,7 +169,7 @@ public final class ProxyBuilder<T> {
      */
     public ProxyBuilder<T> dexCache(File dexCacheParent) {
         dexCache = new File(dexCacheParent, "v" + Integer.toString(VERSION));
-        dexCache.mkdirs();
+        dexCache.mkdir();
         return this;
     }
     

--- a/dexmaker/src/main/java/com/google/dexmaker/stock/ProxyBuilder.java
+++ b/dexmaker/src/main/java/com/google/dexmaker/stock/ProxyBuilder.java
@@ -116,6 +116,10 @@ import java.util.concurrent.CopyOnWriteArraySet;
  * This class is <b>not thread safe</b>.
  */
 public final class ProxyBuilder<T> {
+    // Version of ProxyBuilder. It should be updated if the implementation
+    // of the generated proxy class changes.
+    public static final int VERSION = 1;
+
     private static final String FIELD_NAME_HANDLER = "$__handler";
     private static final String FIELD_NAME_METHODS = "$__methodArray";
 
@@ -163,8 +167,9 @@ public final class ProxyBuilder<T> {
      * DexMaker#generateAndLoad DexMaker.generateAndLoad()} for guidance on
      * choosing a secure location for the dex cache.
      */
-    public ProxyBuilder<T> dexCache(File dexCache) {
-        this.dexCache = dexCache;
+    public ProxyBuilder<T> dexCache(File dexCacheParent) {
+        dexCache = new File(dexCacheParent, "v" + Integer.toString(VERSION));
+        dexCache.mkdirs();
         return this;
     }
     

--- a/dexmaker/src/test/java/com/google/dexmaker/DexMakerTest.java
+++ b/dexmaker/src/test/java/com/google/dexmaker/DexMakerTest.java
@@ -1819,6 +1819,7 @@ public final class DexMakerTest extends TestCase {
         dexMaker.declare(GENERATED, "Generated.java", PUBLIC, TypeId.OBJECT);
         addMethodToDexMakerGenerator(TypeId.INT, defaultMethodName, TypeId.INT);
         generateAndLoad();
+        // DexMaker writes two files to disk at a time: Generated_XXXX.jar and Generated_XXXX.dex.
         assertEquals(origSize + 2, getDataDirectory().listFiles().length);
 
         long lastModified  = getJarFiles()[0].lastModified();
@@ -1905,6 +1906,7 @@ public final class DexMakerTest extends TestCase {
         dexMaker.declare(GENERATED, "Generated.java", PUBLIC, TypeId.get(BlankClassA.class));
         addMethodToDexMakerGenerator(TypeId.INT, defaultMethodName, TypeId.INT);
         generateAndLoad();
+        // DexMaker writes two files to disk at a time: Generated_XXXX.jar and Generated_XXXX.dex.
         assertEquals(origSize + 2, getDataDirectory().listFiles().length);
 
         // Create new dexmaker generator with BlankClassB as supertype.
@@ -1941,6 +1943,7 @@ public final class DexMakerTest extends TestCase {
         dexMaker.declare(GENERATED, "Generated.java", PUBLIC, TypeId.OBJECT);
         addConstructorToDexMakerGenerator(TypeId.INT);
         generateAndLoad();
+        // DexMaker writes two files to disk at a time: Generated_XXXX.jar and Generated_XXXX.dex.
         assertEquals(origSize + 2, getDataDirectory().listFiles().length);
 
         long lastModified  = getJarFiles()[0].lastModified();

--- a/dexmaker/src/test/java/com/google/dexmaker/DexMakerTest.java
+++ b/dexmaker/src/test/java/com/google/dexmaker/DexMakerTest.java
@@ -1897,7 +1897,7 @@ public final class DexMakerTest extends TestCase {
 
     }
 
-    public void testCaching_Types() throws Exception {
+    public void testCaching_DifferentParentClasses() throws Exception {
         int origSize = getDataDirectory().listFiles().length;
         final String defaultMethodName = "call";
 

--- a/dexmaker/src/test/java/com/google/dexmaker/DexMakerTest.java
+++ b/dexmaker/src/test/java/com/google/dexmaker/DexMakerTest.java
@@ -2006,11 +2006,11 @@ public final class DexMakerTest extends TestCase {
         throw new IllegalStateException("no call() method");
     }
 
-    public static File getDataDirectory() {
-        String envVariable = "ANDROID_DATA";
-        String defaultLoc = "/data";
-        String path = System.getenv(envVariable);
-        return path == null ? new File(defaultLoc) : new File(path);
+    public static File getDataDirectory() throws Exception {
+        Class<?> environmentClass = Class.forName("android.os.Environment");
+        Method method = environmentClass.getMethod("getDataDirectory");
+        Object dataDirectory = method.invoke(null);
+        return (File) dataDirectory;
     }
 
     private Class<?> generateAndLoad() throws Exception {

--- a/dexmaker/src/test/java/com/google/dexmaker/DexMakerTest.java
+++ b/dexmaker/src/test/java/com/google/dexmaker/DexMakerTest.java
@@ -66,6 +66,15 @@ public final class DexMakerTest extends TestCase {
     private void reset() {
         dexMaker = new DexMaker();
         dexMaker.declare(GENERATED, "Generated.java", PUBLIC, TypeId.OBJECT);
+        clearDataDirectory();
+    }
+
+    private void clearDataDirectory() {
+        for (File f : getDataDirectory().listFiles()) {
+            if (f.getName().endsWith(".jar") || f.getName().endsWith(".dex")) {
+                f.delete();
+            }
+        }
     }
 
     public void testNewInstance() throws Exception {

--- a/dexmaker/src/test/java/com/google/dexmaker/DexMakerTest.java
+++ b/dexmaker/src/test/java/com/google/dexmaker/DexMakerTest.java
@@ -1814,11 +1814,11 @@ public final class DexMakerTest extends TestCase {
         throw new IllegalStateException("no call() method");
     }
 
-    public static File getDataDirectory() throws Exception {
-        Class<?> environmentClass = Class.forName("android.os.Environment");
-        Method method = environmentClass.getMethod("getDataDirectory");
-        Object dataDirectory = method.invoke(null);
-        return (File) dataDirectory;
+    public static File getDataDirectory() {
+        String envVariable = "ANDROID_DATA";
+        String defaultLoc = "/data";
+        String path = System.getenv(envVariable);
+        return path == null ? new File(defaultLoc) : new File(path);
     }
 
     private Class<?> generateAndLoad() throws Exception {

--- a/dexmaker/src/test/java/com/google/dexmaker/examples/FibonacciMaker.java
+++ b/dexmaker/src/test/java/com/google/dexmaker/examples/FibonacciMaker.java
@@ -69,10 +69,10 @@ public final class FibonacciMaker {
         System.out.println(fibMethod.invoke(null, 8));
     }
 
-    public static File getDataDirectory() throws Exception {
-        Class<?> environmentClass = Class.forName("android.os.Environment");
-        Method method = environmentClass.getMethod("getDataDirectory");
-        Object dataDirectory = method.invoke(null);
-        return (File) dataDirectory;
+    public static File getDataDirectory() {
+        String envVariable = "ANDROID_DATA";
+        String defaultLoc = "/data";
+        String path = System.getenv(envVariable);
+        return path == null ? new File(defaultLoc) : new File(path);
     }
 }

--- a/dexmaker/src/test/java/com/google/dexmaker/examples/FibonacciMaker.java
+++ b/dexmaker/src/test/java/com/google/dexmaker/examples/FibonacciMaker.java
@@ -69,10 +69,10 @@ public final class FibonacciMaker {
         System.out.println(fibMethod.invoke(null, 8));
     }
 
-    public static File getDataDirectory() {
-        String envVariable = "ANDROID_DATA";
-        String defaultLoc = "/data";
-        String path = System.getenv(envVariable);
-        return path == null ? new File(defaultLoc) : new File(path);
+    public static File getDataDirectory() throws Exception {
+        Class<?> environmentClass = Class.forName("android.os.Environment");
+        Method method = environmentClass.getMethod("getDataDirectory");
+        Object dataDirectory = method.invoke(null);
+        return (File) dataDirectory;
     }
 }

--- a/dexmaker/src/test/java/com/google/dexmaker/stock/ProxyBuilderTest.java
+++ b/dexmaker/src/test/java/com/google/dexmaker/stock/ProxyBuilderTest.java
@@ -929,18 +929,13 @@ public class ProxyBuilderTest extends TestCase {
 
     @SuppressWarnings("unchecked")
     public void testMethodsGeneratedInDeterministicOrder() throws Exception {
-        Field mapField = ProxyBuilder.class
-                .getDeclaredField("generatedProxyClasses");
-        mapField.setAccessible(true);
-
         // Grab the static methods array from the original class.
         Method[] methods1 = getMethodsForProxyClass(TestOrderingClass.class);
         assertNotNull(methods1);
 
         // Clear ProxyBuilder's in-memory cache of classes. This will force
         // it to rebuild the class and reset the static methods field.
-        Map<Class<?>, Class<?>> map = (Map<Class<?>, Class<?>>) mapField
-                .get(null);
+        Map<Class<?>, Class<?>> map = getGeneratedProxyClasses();
         assertNotNull(map);
         map.clear();
 
@@ -965,5 +960,12 @@ public class ProxyBuilderTest extends TestCase {
         }
 
         return methods;
+    }
+
+    private Map<Class<?>, Class<?>> getGeneratedProxyClasses() throws Exception {
+        Field mapField = ProxyBuilder.class
+                .getDeclaredField("generatedProxyClasses");
+        mapField.setAccessible(true);
+        return (Map<Class<?>, Class<?>>) mapField.get(null);
     }
 }

--- a/dexmaker/src/test/java/com/google/dexmaker/stock/ProxyBuilderTest.java
+++ b/dexmaker/src/test/java/com/google/dexmaker/stock/ProxyBuilderTest.java
@@ -33,6 +33,24 @@ import junit.framework.TestCase;
 
 public class ProxyBuilderTest extends TestCase {
     private FakeInvocationHandler fakeHandler = new FakeInvocationHandler();
+    private File versionedDxDir = new File(DexMakerTest.getDataDirectory(), "v1");
+
+    public void setUp() throws Exception {
+        super.setUp();
+        versionedDxDir.mkdirs();
+        clearVersionedDxDir();
+    }
+
+    public void tearDown() throws Exception {
+        clearVersionedDxDir();
+        super.tearDown();
+    }
+
+    private void clearVersionedDxDir() {
+        for (File f : versionedDxDir.listFiles()) {
+            f.delete();
+        }
+    }
 
     public static class SimpleClass {
         public String simpleMethod() {
@@ -44,6 +62,7 @@ public class ProxyBuilderTest extends TestCase {
         fakeHandler.setFakeResult("expected");
         SimpleClass proxy = proxyFor(SimpleClass.class).build();
         assertEquals("expected", proxy.simpleMethod());
+        assertEquals(2, versionedDxDir.listFiles().length);
     }
 
     public static class ConstructorTakesArguments {

--- a/dexmaker/src/test/java/com/google/dexmaker/stock/ProxyBuilderTest.java
+++ b/dexmaker/src/test/java/com/google/dexmaker/stock/ProxyBuilderTest.java
@@ -964,6 +964,15 @@ public class ProxyBuilderTest extends TestCase {
     }
 
     public void testOrderingClassWithDexMakerCaching() throws Exception {
+        doTestOrderClassWithDexMakerCaching();
+
+        // Force ProxyBuilder to call DexMaker.generateAndLoad()
+        getGeneratedProxyClasses().clear();
+
+        doTestOrderClassWithDexMakerCaching();
+    }
+
+    private void doTestOrderClassWithDexMakerCaching() throws Exception {
         TestOrderingClass proxy = ProxyBuilder.forClass(TestOrderingClass.class)
                 .handler(new InvokeSuperHandler())
                 .dexCache(DexMakerTest.getDataDirectory())
@@ -974,22 +983,6 @@ public class ProxyBuilderTest extends TestCase {
         assertFalse(proxy.returnsBoolean());
         assertEquals(1.0, proxy.returnsDouble());
         assertNotNull(proxy.returnsObject());
-        assertEquals(2, versionedDxDir.listFiles().length);
-
-        // Force ProxyBuilder to call DexMaker.generateAndLoad()
-        getGeneratedProxyClasses().clear();
-
-        proxy = ProxyBuilder.forClass(TestOrderingClass.class)
-                .handler(new InvokeSuperHandler())
-                .dexCache(DexMakerTest.getDataDirectory())
-                .build();
-        assertEquals(0, proxy.returnsInt());
-        assertEquals(1, proxy.returnsInt(1, 1));
-        assertEquals("string", proxy.returnsString());
-        assertFalse(proxy.returnsBoolean());
-        assertEquals(1.0, proxy.returnsDouble());
-        assertNotNull(proxy.returnsObject());
-        // the class should be already cached.
         assertEquals(2, versionedDxDir.listFiles().length);
     }
 


### PR DESCRIPTION
@dshirley @swankjesse Please review. It's probably easiest to go commit by commit.

The idea behind this change is to have DexMaker reuse classes it generates in previous sessions. In like with comments by @swankjesse, I took a more opinionated approach and make this the only behavior (i.e. unlike my earlier pull request, there's no reuse() API call). Validation of classes is done at two levels:

- The file names contain a checksum of the method signatures and superclass. This should protect against a stale cache being reused when an app or the OS is upgraded.
- ProxyBuilder now has a version number which is included in the directory structure of the dex cache. We would need to update this whenever we modify the way in which ProxyBuilder generates proxy classes. This should protect against a stale cache being reused if a new version of the dexmaker is place inside someone's code. 