### PR TITLE
Update AppDataDirGuesser for BaseDexClassLoader

### DIFF
--- a/dexmaker/src/main/java/com/google/dexmaker/AppDataDirGuesser.java
+++ b/dexmaker/src/main/java/com/google/dexmaker/AppDataDirGuesser.java
@@ -61,12 +61,74 @@ class AppDataDirGuesser {
         }
 
         // Parsing toString() method: yuck.  But no other way to get the path.
-        // Strip out the bit between square brackets, that's our path.
         String result = classLoader.toString();
-        int index = result.lastIndexOf('[');
-        result = (index == -1) ? result : result.substring(index + 1);
-        index = result.indexOf(']');
-        return (index == -1) ? result : result.substring(0, index);
+        return processClassLoaderString(result);
+    }
+
+    /**
+     * Given the result of a ClassLoader.toString() call, process the result so that guessPath
+     * can use it. There are currently two variants. For Android 4.3 and later, the string
+     * "DexPathList" should be recognized and the array of dex path elements is parsed. for
+     * earlier versions, the last nested array ('[' ... ']') is enclosing the string we are
+     * interested in.
+     */
+    static String processClassLoaderString(String input) {
+        if (input.contains("DexPathList")) {
+            return processClassLoaderString43OrLater(input);
+        } else {
+            return processClassLoaderString42OrEarlier(input);
+        }
+    }
+
+    private static String processClassLoaderString42OrEarlier(String input) {
+        /* The toString output looks like this:
+         * dalvik.system.PathClassLoader[dexPath=path/to/apk,libraryPath=path/to/libs]
+         */
+        int index = input.lastIndexOf('[');
+        input = (index == -1) ? input : input.substring(index + 1);
+        index = input.indexOf(']');
+        input = (index == -1) ? input : input.substring(0, index);
+        return input;
+    }
+
+    private static String processClassLoaderString43OrLater(String input) {
+        /* The toString output looks like this:
+         * dalvik.system.PathClassLoader[DexPathList[[zip file "/data/app/{NAME}", ...], nativeLibraryDirectories=[...]]]
+         */
+        int start = input.indexOf("DexPathList") + "DexPathList".length();
+        if (input.length() > start + 4) {  // [[ + ]]
+            String trimmed = input.substring(start);
+            int end = trimmed.indexOf(']');
+            if (trimmed.charAt(0) == '[' && trimmed.charAt(1) == '[' && end >= 0) {
+                trimmed = trimmed.substring(2, end);
+                // Comma-separated list, Arrays.toString output.
+                String split[] = trimmed.split(",");
+
+                // Clean up parts. Each path element is the type of the element plus the path in
+                // quotes.
+                for (int i = 0; i < split.length; i++) {
+                    int quoteStart = split[i].indexOf('"');
+                    int quoteEnd = split[i].lastIndexOf('"');
+                    if (quoteStart > 0 && quoteStart < quoteEnd) {
+                        split[i] = split[i].substring(quoteStart + 1, quoteEnd);
+                    }
+                }
+
+                // Need to rejoin components.
+                StringBuilder sb = new StringBuilder();
+                for (String s : split) {
+                    if (sb.length() > 0) {
+                        sb.append(':');
+                    }
+                    sb.append(s);
+                }
+                return sb.toString();
+            }
+        }
+
+        // This is technically a parsing failure. Return the original string, maybe a later
+        // stage can still salvage this.
+        return input;
     }
 
     File[] guessPath(String input) {


### PR DESCRIPTION
Since Jelly Bean 4.3 the toString of a BaseDexClassLoader has had a
different format. Update the AppDataDirGuesser to understand that
format.