### PR TITLE
Update to mockito-core 1.10.+

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Dexmaker includes class proxy support for [Mockito](http://code.google.com/p/moc
 and the dexmaker `.jar` files to your Android test project's `libs/` directory and you can use Mockito
 in your Android unit tests.
 
-This requires Mockito 1.9.5 or newer.
+This requires Mockito 1.10.5 or newer.
 
 Runtime Code Generation
 -----------------------

--- a/mockito/pom.xml
+++ b/mockito/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.9.5</version>
+            <version>1.10.5</version>
         </dependency>
     </dependencies>
 

--- a/mockito/src/main/java/com/google/dexmaker/mockito/InvocationHandlerAdapter.java
+++ b/mockito/src/main/java/com/google/dexmaker/mockito/InvocationHandlerAdapter.java
@@ -19,6 +19,8 @@ package com.google.dexmaker.mockito;
 import com.google.dexmaker.stock.ProxyBuilder;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
 import org.mockito.internal.invocation.InvocationImpl;
 import org.mockito.internal.invocation.MockitoMethod;
 import org.mockito.internal.invocation.realmethod.RealMethod;
@@ -91,6 +93,10 @@ final class InvocationHandlerAdapter implements InvocationHandler {
 
         public Object invoke(Object target, Object[] arguments) throws Throwable {
             return ProxyBuilder.callSuper(target, method, arguments);
+        }
+
+        public boolean isAbstract() {
+            return Modifier.isAbstract(method.getModifiers());
         }
     }
 }


### PR DESCRIPTION
As of mockito 1.10.5 (actually 1.10.0, but this tag was not published) a new interface, AbstractAwareMethod, was introduced to MockitoMethod.  This new interface includes the method isAbstract().  This change broke compatibility beyond Mockito 1.9.5.  

This pull request includes the bump to the minimum of mockito-core 1.10.5 and what I think is a reasonable implementation of InvocationHandlerAdapter.ProxiedMethod.isAbstract() to reach interface-compatibility.

I was able to compile and run the unit tests (With some minor hacking around Vogar, which expected dx to live in `<android_sdk/platform-tools>`, when in reality it lives in `<android_sdk/build-tools/sdk_version>`.  I also had to remount rootfs on the emulator... it is probably worth updating the README to reflect this), and everything is passing.  

Let me know what you think.  Thanks!