### PR TITLE
Fix outdated package name String

### DIFF
--- a/mockito/src/main/java/com/android/dx/mockito/DexmakerMockMaker.java
+++ b/mockito/src/main/java/com/android/dx/mockito/DexmakerMockMaker.java
@@ -101,7 +101,7 @@ public final class DexmakerMockMaker implements MockMaker, StackTraceCleanerProv
                 return defaultCleaner.isOut(candidate)
                         || candidate.getClassName().endsWith("_Proxy") // dexmaker class proxies
                         || candidate.getClassName().startsWith("$Proxy") // dalvik interface proxies
-                        || candidate.getClassName().startsWith("com.google.dexmaker.mockito.");
+                        || candidate.getClassName().startsWith("com.android.dx.mockito.");
             }
         };
     }


### PR DESCRIPTION
For me this fixes the issues which seem to have arisen for Android users with versions 1.3 and 1.4.
https://github.com/crittercism/dexmaker/issues/20 & various comments on other issues

Thanks to the wonders of jitpack.io you can try this out by adding this to your build script:

````
repositories {
    maven { url "https://jitpack.io" }
}

dependencies {
    androidTestCompile 'com.github.vaughandroid:dexmaker:v1.5-SNAPSHOT'
}
````