### PR TITLE
Deal will null members when determinin…

### DIFF
--- a/mockito/pom.xml
+++ b/mockito/pom.xml
@@ -35,6 +35,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.crittercism.dexmaker</groupId>
+            <artifactId>dexmaker-dx</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>1.10.5</version>

--- a/mockito/src/main/java/com/android/dx/mockito/DexmakerMockMaker.java
+++ b/mockito/src/main/java/com/android/dx/mockito/DexmakerMockMaker.java
@@ -78,6 +78,9 @@ public final class DexmakerMockMaker implements MockMaker, StackTraceCleanerProv
     }
 
     private InvocationHandlerAdapter getInvocationHandlerAdapter(Object mock) {
+        if (mock == null) {
+            return null;
+        }
         if (Proxy.isProxyClass(mock.getClass())) {
             InvocationHandler invocationHandler = Proxy.getInvocationHandler(mock);
             return invocationHandler instanceof InvocationHandlerAdapter


### PR DESCRIPTION
It seems it is quite easy for mockito to pass these in.
Also adds dexmaker-dx dependencto dexmaker-mockito since one won't work without the other